### PR TITLE
Namespace required for build.gradle in latest android migration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
+namespace "id.my.alan.share_whatsapp"
 android {
     compileSdkVersion 31
 


### PR DESCRIPTION
Namespace required for build.gradle in latest android migration to run the flutter application. @alann-maulana  accept this pull request to update the plugin.